### PR TITLE
Fix preprocess fallback

### DIFF
--- a/projectForDeepLearing.ipynb
+++ b/projectForDeepLearing.ipynb
@@ -124,6 +124,8 @@
     "        x, y, w, h = cv2.boundingRect(max_contour)\n",
     "        output_image = binary_image[y:y + h, x:x + w]\n",
     "        output_image = cv2.resize(output_image, (80, 80))\n",
+    "    else:\n",
+    "        output_image = cv2.resize(binary_image2, (80, 80))\n",
     "    return output_image"
    ]
   },
@@ -873,6 +875,8 @@
     "        output_image = binary_image2[y:y + h, x:x + w]\n",
     "        # resize\n",
     "        output_image = cv2.resize(output_image, (80, 80))\n",
+    "    else:\n",
+    "        output_image = cv2.resize(binary_image2, (80, 80))\n",
     "    return output_image\n",
     "\n",
     "def build_dataset(root_dir, class_name):\n",


### PR DESCRIPTION
## Summary
- avoid undefined variable when contours are missing by resizing the original thresholded image instead

## Testing
- `python -m json.tool projectForDeepLearing.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_68595c207dd083219eeb15ff0c684b4e